### PR TITLE
Update 040.SQL数据库配置源.md

### DIFF
--- a/docs/10.v2.9.X文档/050.🗂规则文件/040.SQL数据库配置源.md
+++ b/docs/10.v2.9.X文档/050.🗂规则文件/040.SQL数据库配置源.md
@@ -34,7 +34,8 @@ liteflow.rule-source-ext-data={\
   "username":"root",\
   "password":"123456",\
   "tableName":"chain",\
-  "elDataField":"el_data"\
+  "elDataField":"el_data",\
+  "chainNameField":"chain_name"\
 }
 ```
   </code-block>
@@ -49,6 +50,7 @@ liteflow:
     password: 123456
     tableName: chain
     elDataField: el_data
+    chainNameField: chain_name
 ```
   </code-block>
 </code-group>


### PR DESCRIPTION
db配置中的示范缺少了一个参数：chainNameField，尽管在下发的文字中已经说明，但是这对于直接复制配置的人来讲，依然具有困惑性