### PR TITLE
@LiteFlowMethod注解，声明式定义组件时，入参示例说明更新

### DIFF
--- a/docs/09.v2.10.X文档/086.🍇声明式组件/020.类级别式声明.md
+++ b/docs/09.v2.10.X文档/086.🍇声明式组件/020.类级别式声明.md
@@ -28,12 +28,12 @@ public class ACmp{
 	}
 
 	@LiteflowMethod(LiteFlowMethodEnum.BEFORE_PROCESS)
-	public void beforeAcmp(String nodeId, Slot slot){
+	public void beforeAcmp(NodeComponent bindCmp){
 		System.out.println("before A");
 	}
 
 	@LiteflowMethod(LiteFlowMethodEnum.AFTER_PROCESS)
-	public void afterAcmp(String nodeId, Slot slot){
+	public void afterAcmp(NodeComponent bindCmp){
 		System.out.println("after A");
 	}
 
@@ -61,7 +61,7 @@ public class ACmp{
 
 ::: tip 注意点1
 
-这里注意的是，大部分方法上参数必须传入`NodeComponent bindCmp`这个参数，而且必须只有一个参数，否则会报错，而`beforeProcess`和`afterProcess`还是按照以前的参数定义。这点要注意下，可以查看上面的示例。
+这里注意的是，大部分方法上参数必须传入`NodeComponent bindCmp`这个参数，而且必须只有一个参数，否则会报错。这点要注意下，可以查看上面的示例。
 
 以前获取上下文Bean是用`this`关键字，现在只需从bindCmp中获取就可以了。
 


### PR DESCRIPTION
@LiteFlowMethod注解定义声明式组件方法时，入参说明有误。更新beforeProcess和afterProcess方法参数定义为：NodeComponent bindCmp