### PR TITLE
Update 020.配置.md

### DIFF
--- a/docs/07.v2.12.X文档/030.🍟快速开始(Hello world)/020.🌱Spring场景安装运行/020.配置.md
+++ b/docs/07.v2.12.X文档/030.🍟快速开始(Hello world)/020.🌱Spring场景安装运行/020.配置.md
@@ -59,7 +59,7 @@ public class CCmp extends NodeComponent {
 
 <!-- 如果上述enableLog为false，下面这段也可以省略 -->
 <bean class="com.yomahub.liteflow.monitor.MonitorBus">
-    <property name="liteflowConfig" ref="liteflowConfig"/>
+    <constructor-arg ref="liteflowConfig" />
 </bean>
 ```
 


### PR DESCRIPTION
com.yomahub.liteflow.monitor.MonitorBus类中没有无参构造方法，可以在里面添加无参构造方法，或者将<property>修改为<constructor-arg> 本次修改时候后者，改动最小。