### PR TITLE
fix: 消除文档歧义

### DIFF
--- a/docs/05.v2.15.X文档/100.🍋脚本组件/015.脚本与Java进行交互.md
+++ b/docs/05.v2.15.X文档/100.🍋脚本组件/015.脚本与Java进行交互.md
@@ -148,7 +148,7 @@ public class DemoBean4 {
 这样你在脚本中只能访问到`test1`方法了。
 
 ::: tip
-需要注意的是，java对象在spring体系中一定要注册进上下文，如果不注册进上下文，光加`@ScriptBean`注解也是没用的。
+需要注意的是，java对象在spring体系中一定要通过@Service/@Component注册进spring的上下文。如果不注册进上下文，光加`@ScriptBean`注解也是没用的。
 :::
 
 在非spring体系下面，如果你要把自己的定义的java对象注入脚本，则需要手动写代码（最好在启动应用的时候）：
@@ -187,6 +187,6 @@ public class DemoBean1 {
 这样，你就可以在脚本中用`demo.getDemoStr1()`来调用到相应的java方法了。
 
 ::: tip
-当然这里的前提同样是：java对象在spring体系中一定要注册进上下文，如果不注册进上下文，光加`@ScriptMethod`注解也是没用的。
+当然这里的前提同样是：java对象在spring体系中一定要注册进spring的上下文，如果不注册进上下文，光加`@ScriptMethod`注解也是没用的。
 :::
 


### PR DESCRIPTION
这里面“上下文”没有明确是spring的上下文还是LiteFlow的上下文，很容易引起误解。